### PR TITLE
Remove hardcoded paths; introduce `config.sh` for user-specific settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 logs/
 data/climbmix_small/
+config.sh

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Achieve the highest tokens/sec/GPU for a given model size on up to 8 nodes (32 G
 
 ```bash
 cp config.sh.example config.sh
-# Edit config.sh: set WORKDIR (your scratch directory), ACCOUNT (your SLURM account), and WANDB_API_KEY (optional)
+# Edit config.sh: set WORKDIR (your scratch directory), SBATCH_ACCOUNT (your SLURM account), and WANDB_API_KEY (optional)
 source config.sh
 ```
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,50 @@ Achieve the highest tokens/sec/GPU for a given model size on up to 8 nodes (32 G
 | Single-Node | ~32B | Intra-node tensor parallelism (TP=4) |
 | Multi-Node | ~140B | Pipeline parallelism across nodes (TP=4, PP=4) |
 
+## Setup
+
+**1. Configure your paths:**
+
+```bash
+cp config.sh.example config.sh
+# Edit config.sh: set WORKDIR (your scratch directory), ACCOUNT (your SLURM account), and WANDB_API_KEY (optional)
+source config.sh
+```
+
+`config.sh` is git-ignored; the example file is committed as a template.
+
+**2. Initialize the Megatron-LM submodule:**
+
+The `Megatron-LM/` directory is empty after cloning. Remove any leftover files and initialize:
+
+```bash
+rm -rf Megatron-LM
+git submodule update --init
+```
+
+**3. Set up the EDF container environment:**
+
+Copy [`alps3.toml`](alps3.toml) to `~/.edf/` and update `workdir` to your home directory:
+
+```bash
+mkdir -p ~/.edf
+sed "s|workdir = .*|workdir = \"$HOME\"|" alps3.toml > ~/.edf/alps3.toml
+```
+
+**4. Verify the infrastructure:**
+
+```bash
+sbatch test-infra.sbatch
+```
+
+**5. Benchmark Megatron-LM training throughput:**
+
+Run a `125m` model benchmark with 50 steps on a single node:
+
+```bash
+./launch.sh throughput 125m 50 1
+```
+
 ## Container Image
 
 We use the **alps3** extended image based on NGC PyTorch 26.01-py3:
@@ -92,7 +136,7 @@ All training is launched via `launch.sh <mode> <model_size> [steps] [nodes]`. Th
 
 ### Logging
 
-- **W&B**: Enabled automatically if `WANDB_API_KEY` is set in your shell environment on Clariden. Add `export WANDB_API_KEY=<your-key>` to your `~/.bashrc`.
+- **W&B**: Enabled automatically if `WANDB_API_KEY` is set in `config.sh`, or in your shell environment on Clariden. Add `export WANDB_API_KEY=<your-key>` to your `~/.bashrc`.
 - **Tensorboard**: Written to `/iopsstor/scratch/cscs/$USER/gipfelsturm/<project>/<exp>/tensorboard/`
 - **Checkpoints**: Saved to `/iopsstor/scratch/cscs/$USER/gipfelsturm/<project>/<exp>/checkpoints/` (`torch` format). Currently disabled due to a [known SIGSEGV bug](https://github.com/NVIDIA/Megatron-LM/issues/1861) in checkpoint saving on GH200/ARM64. Note: iopsstor scratch has a three-week deletion policy.
 

--- a/config.sh.example
+++ b/config.sh.example
@@ -1,0 +1,5 @@
+# Copy this file to config.sh and fill in your values.
+# config.sh is git-ignored so your personal paths are never committed.
+export WORKDIR="/iopsstor/scratch/cscs/your_cscs_account/gipfelsturm"
+export ACCOUNT="lsaie-ss26"
+export WANDB_API_KEY=""

--- a/config.sh.example
+++ b/config.sh.example
@@ -1,5 +1,10 @@
 # Copy this file to config.sh and fill in your values.
 # config.sh is git-ignored so your personal paths are never committed.
+
 export WORKDIR="/iopsstor/scratch/cscs/your_cscs_account/gipfelsturm"
-export ACCOUNT="lsaie-ss26"
+
+# The SBATCH_ACCOUNT variable name is reserved by Slurm and automatically passed
+# as the account to sbatch.
+export SBATCH_ACCOUNT="lsaie-ss26"
+
 export WANDB_API_KEY=""

--- a/data/convert_data.sbatch
+++ b/data/convert_data.sbatch
@@ -8,7 +8,7 @@
 #SBATCH --output=logs/convert_data_%j.log
 #SBATCH --error=logs/convert_data_%j.log
 
-WORKDIR=/users/schlag/gipfelsturm
+source "$(dirname "$0")/../config.sh"
 INPUT=/capstor/store/cscs/swissai/infra01/datasets/nvidia/Nemotron-ClimbMix/climbmix_small
 OUTPUT=/capstor/store/cscs/swissai/infra01/datasets/nvidia/Nemotron-ClimbMix/climbmix_small_megatron/climbmix_small
 

--- a/data/convert_data.sbatch
+++ b/data/convert_data.sbatch
@@ -1,6 +1,5 @@
 #!/bin/bash
 #SBATCH --job-name=parquet-to-megatron
-#SBATCH --account=infra01
 #SBATCH --partition=normal
 #SBATCH --nodes=1
 #SBATCH --ntasks-per-node=1
@@ -8,7 +7,7 @@
 #SBATCH --output=logs/convert_data_%j.log
 #SBATCH --error=logs/convert_data_%j.log
 
-source "$(dirname "$0")/../config.sh"
+WORKDIR=${WORKDIR:-$SLURM_SUBMIT_DIR}
 INPUT=/capstor/store/cscs/swissai/infra01/datasets/nvidia/Nemotron-ClimbMix/climbmix_small
 OUTPUT=/capstor/store/cscs/swissai/infra01/datasets/nvidia/Nemotron-ClimbMix/climbmix_small_megatron/climbmix_small
 

--- a/data/download_climbmix.sh
+++ b/data/download_climbmix.sh
@@ -3,8 +3,10 @@
 # Run directly on the login node: bash data/download_climbmix.sh
 set -euo pipefail
 
+source "$(dirname "$0")/../config.sh"
+
 DATA_DIR="/capstor/store/cscs/swissai/infra01/datasets/nvidia/Nemotron-ClimbMix/climbmix_small"
-LOGFILE="/users/schlag/gipfelsturm/data/download_climbmix.log"
+LOGFILE="$WORKDIR/data/download_climbmix.log"
 
 mkdir -p "$DATA_DIR"
 

--- a/launch.sh
+++ b/launch.sh
@@ -17,6 +17,8 @@
 
 set -euo pipefail
 
+source "$(dirname "$0")/config.sh"
+
 MODE=${1:?Usage: ./launch.sh <mode> <model_size> [steps] [nodes]}
 MODEL_SIZE=${2:?Usage: ./launch.sh <mode> <model_size> [steps] [nodes]}
 
@@ -30,7 +32,7 @@ case $MODE in
         EVAL_ITERS=0
         LR_WARMUP_ITERS=10
         LOGGING_EXTRA=""
-        WANDB=false
+        WANDB=true
         ;;
     train)
         TRAINING_STEPS=${3:?Usage: ./launch.sh train <model_size> <steps> [nodes]}
@@ -115,7 +117,7 @@ cat > "$SCRIPT" << 'HEADER'
 HEADER
 
 cat >> "$SCRIPT" << SBATCH_DIRECTIVES
-#SBATCH --account=infra01
+#SBATCH --account=${ACCOUNT}
 #SBATCH --time=${TIME}
 #SBATCH --job-name=${JOB_NAME}
 #SBATCH --output=logs/%x-%j.log
@@ -128,16 +130,19 @@ cat >> "$SCRIPT" << SBATCH_DIRECTIVES
 #SBATCH --no-requeue
 SBATCH_DIRECTIVES
 
-cat >> "$SCRIPT" << 'BODY'
+cat >> "$SCRIPT" << 'BODY_HEAD'
 
-echo "START TIME: $(date)"
+echo "START TIME: \$(date)"
 
 ################ Configs ################
-WORKDIR=/users/schlag/gipfelsturm
-MEGATRON_LM_DIR=$WORKDIR/Megatron-LM
+BODY_HEAD
+
+cat >> "$SCRIPT" << BODY_WORKDIR
+WORKDIR=${WORKDIR}
+MEGATRON_LM_DIR=\$WORKDIR/Megatron-LM
 DATA_PREFIX=/capstor/store/cscs/swissai/infra01/datasets/nvidia/Nemotron-ClimbMix/climbmix_small_megatron/climbmix_small
-DATASET_CACHE_DIR=/iopsstor/scratch/cscs/$USER/gipfelsturm/cache
-BODY
+DATASET_CACHE_DIR=/iopsstor/scratch/cscs/\$USER/gipfelsturm/cache
+BODY_WORKDIR
 
 cat >> "$SCRIPT" << CONFIGS
 

--- a/launch.sh
+++ b/launch.sh
@@ -2,7 +2,7 @@
 #
 # Usage: ./launch.sh <mode> <model_size> [steps] [nodes]
 #
-# Modes:     throughput  (50 steps, no logging)
+# Modes:     throughput  (50 steps, with W&B)
 #            train       (N steps, with W&B and Tensorboard)
 #
 # Sizes:     125m, 350m, 760m, 1.5b, 3b, 8b

--- a/test-infra.sbatch
+++ b/test-infra.sbatch
@@ -1,6 +1,6 @@
 #!/bin/bash
 #SBATCH --job-name=gipfel-infra
-#SBATCH --account=infra01
+#SBATCH --account=lsaie-ss26
 #SBATCH --nodes=4
 #SBATCH --ntasks-per-node=1
 #SBATCH --gpus-per-node=4
@@ -10,7 +10,7 @@
 #SBATCH --output=logs/%x-%j.log
 #SBATCH --error=logs/%x-%j.log
 
-WORKDIR=/users/schlag/gipfelsturm
+WORKDIR=${WORKDIR:-$SLURM_SUBMIT_DIR}
 
 mkdir -p logs
 

--- a/test-infra.sbatch
+++ b/test-infra.sbatch
@@ -1,6 +1,5 @@
 #!/bin/bash
 #SBATCH --job-name=gipfel-infra
-#SBATCH --account=lsaie-ss26
 #SBATCH --nodes=4
 #SBATCH --ntasks-per-node=1
 #SBATCH --gpus-per-node=4


### PR DESCRIPTION
Several files contain hardcoded paths and accont names that do not work in student's environment. This PR replaces all hardcoded values with a single `config.sh` file that each user fills in once.

* Adds `config.sh.example` as a config template; `config.sh` is git-ignored to avoid leaks
* All scripts now rely on `config.sh` to import variables
* `README` updated with a setup section